### PR TITLE
.env.example comments: "#" and not "//"

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,7 +66,7 @@ VITE_APP_NAME="${APP_NAME}"
 # --------------------------------------------------------
 # custom
 # --------------------------------------------------------
-GOD_MODE=true // this allows developers to see ALL persons in ALL teams
+GOD_MODE=true # this allows developers to see ALL persons in ALL teams
 
 BACKUP_DISK="backups"
 BACKUP_DAILY_CLEANUP="22:30"


### PR DESCRIPTION
Without this change, installation didn't work for me.

I did `cp .env.example .env` and then `composer install`.

On the last step, it finished with this error:

```
Generating optimized autoload files
> Illuminate\Foundation\ComposerScripts::postAutoloadDump
> @php artisan package:discover --ansi
The environment file is invalid!
Failed to parse dotenv file. Encountered unexpected whitespace at [true // this allows developers to see ALL persons in ALL teams].
Script @php artisan package:discover --ansi handling the post-autoload-dump event returned with error code 1
```
