### PR TITLE
- should fix table settings not found when installing app

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -38,17 +38,19 @@ class AppServiceProvider extends ServiceProvider
 
         $this->addAboutCommandDetails();
 
-        // Cache the applications settings
-        $this->app->singleton('settings', function () {
-            return Cache::rememberForever('settings', function () {
-                return Setting::all()->pluck('value', 'key');
+        if (\Schema::hasTable('settings')) {
+            // Cache the applications settings
+            $this->app->singleton('settings', function () {
+                return Cache::rememberForever('settings', function () {
+                    return Setting::all()->pluck('value', 'key');
+                });
             });
-        });
 
-        // enable/disable logging based on application settings
-        $this->logAllQueries();
-        $this->LogAllQueriesSlow();
-        $this->logAllQueriesNplusone();
+            // enable/disable logging based on application settings
+            $this->logAllQueries();
+            $this->LogAllQueriesSlow();
+            $this->logAllQueriesNplusone();
+        }
     }
 
     /**


### PR DESCRIPTION
During install:
When calling php artisan (e.g. php artisan migrate) the error "SQLSTATE[42S02]: Base table or view not found: 1146 Table 'dbs13582680.settings' doesn't exist" occurs since the settings table has not been created yet.