### PR TITLE
Chore: remove mysql concrete queries for pgsql compatiblity

### DIFF
--- a/app/Livewire/People/Ancestors.php
+++ b/app/Livewire/People/Ancestors.php
@@ -7,6 +7,7 @@ namespace App\Livewire\People;
 use App\Models\Person;
 use App\Queries\AncestorQuery;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use Illuminate\View\View;
 use Livewire\Component;
 
@@ -74,8 +75,7 @@ final class Ancestors extends Component
      */
     private function loadAncestors(): void
     {
-        AncestorQuery::get($this->person->id, $this->count_max);
-        $this->ancestors = collect();
+        $this->ancestors = collect(DB::select(AncestorQuery::get($this->person->id, $this->count_max)));
 
         $maxDegree       = $this->ancestors->max('degree');
         $this->count_max = min($maxDegree + 1, $this->count_max);

--- a/app/Livewire/People/Ancestors.php
+++ b/app/Livewire/People/Ancestors.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace App\Livewire\People;
 
 use App\Models\Person;
+use App\Queries\AncestorQuery;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\DB;
 use Illuminate\View\View;
 use Livewire\Component;
 
@@ -74,7 +74,8 @@ final class Ancestors extends Component
      */
     private function loadAncestors(): void
     {
-        $this->ancestors = collect(DB::select($this->getRecursiveQuery()));
+        AncestorQuery::get($this->person->id, $this->count_max);
+        $this->ancestors = collect();
 
         $maxDegree       = $this->ancestors->max('degree');
         $this->count_max = min($maxDegree + 1, $this->count_max);
@@ -82,48 +83,5 @@ final class Ancestors extends Component
         if ($this->count > $this->count_max) {
             $this->count = $this->count_max;
         }
-    }
-
-    /**
-     * Build the recursive query for ancestors.
-     */
-    private function getRecursiveQuery(): string
-    {
-        $personId = $this->person->id;
-        $countMax = $this->count_max;
-
-        return "
-            WITH RECURSIVE ancestors AS (
-                SELECT
-                    id, firstname, surname, sex, father_id, mother_id, dod, yod, team_id, photo,
-                    0 AS degree,
-                    CAST(id AS CHAR(1024)) AS sequence
-                FROM people
-                WHERE deleted_at IS NULL AND id = $personId
-
-                UNION ALL
-
-                SELECT
-                    p.id, p.firstname, p.surname, p.sex, p.father_id, p.mother_id, p.dod, p.yod, p.team_id, p.photo,
-                    a.degree + 1 AS degree,
-                    CAST(CONCAT_WS(',', a.sequence, p.id) AS CHAR(1024)) AS sequence
-                FROM people p
-                JOIN ancestors a ON a.father_id = p.id
-                WHERE p.deleted_at IS NULL AND a.degree < $countMax
-
-                UNION ALL
-
-                SELECT
-                    p.id, p.firstname, p.surname, p.sex, p.father_id, p.mother_id, p.dod, p.yod, p.team_id, p.photo,
-                    a.degree + 1 AS degree,
-                    CAST(CONCAT_WS(',', a.sequence, p.id) AS CHAR(1024)) AS sequence
-                FROM people p
-                JOIN ancestors a ON a.mother_id = p.id
-                WHERE p.deleted_at IS NULL AND a.degree < $countMax
-            )
-
-            SELECT * FROM ancestors
-            ORDER BY degree, sex DESC;
-        ";
     }
 }

--- a/app/Models/Person.php
+++ b/app/Models/Person.php
@@ -18,7 +18,6 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Korridor\LaravelHasManyMerged\HasManyMerged;
 use Korridor\LaravelHasManyMerged\HasManyMergedRelation;
@@ -152,7 +151,7 @@ final class Person extends Model implements HasMedia
 
             $query
                 ->where(function ($q) use ($year): void {
-                    $q->whereNull('dob')->orWhere(DB::raw('YEAR(dob)'), '>=', $year);
+                    $q->whereNull('dob')->orWhereYear('dob', '>=', $year);
                 })
                 ->where(function ($q) use ($year): void {
                     $q->whereNull('yob')->orWhere('yob', '>=', $year);
@@ -167,9 +166,7 @@ final class Person extends Model implements HasMedia
             $year = (int) $year;
 
             $query
-                ->where(function ($q) use ($year): void {
-                    $q->whereNull('dob')->orWhere(DB::raw('YEAR(dob)'), '<=', $year);
-                })
+                ->where(fn (Builder $q) => $q->whereNull('dob')->orWhereYear('dob', '<=', $year))
                 ->where(function ($q) use ($year): void {
                     $q->whereNull('yob')->orWhere('yob', '<=', $year);
                 });
@@ -189,7 +186,10 @@ final class Person extends Model implements HasMedia
 
             $query
                 ->where(function ($q) use ($min_year, $max_year): void {
-                    $q->whereNull('dob')->orWhereBetween(DB::raw('YEAR(dob)'), [$min_year, $max_year]);
+                    $q->whereNull('dob')
+                        ->orWhere(fn (Builder $q) => $q->whereYear('dob', '>=', $min_year)
+                            ->whereYear('dob', '<=', $max_year)
+                        );
                 })
                 ->where(function ($q) use ($min_year, $max_year): void {
                     $q->whereNull('yob')->orWhereBetween('yob', [$min_year, $max_year]);

--- a/app/Queries/AncestorQuery.php
+++ b/app/Queries/AncestorQuery.php
@@ -12,6 +12,7 @@ class AncestorQuery
     {
         return match (DB::getDriverName()) {
             'mysql' => self::getForMySQL($personId, $countMax),
+            'pgsql' => self::getForPostgres($personId, $countMax),
         };
     }
 
@@ -48,6 +49,54 @@ class AncestorQuery
         )
 
         SELECT * FROM ancestors
+        ORDER BY degree, sex DESC;
+        ";
+    }
+
+    protected static function getForPostgres(int $personId, int $countMax): string
+    {
+        return "
+        WITH RECURSIVE ancestors AS (
+            -- Base case: starting person
+            SELECT
+                id,
+                firstname,
+                surname,
+                sex,
+                father_id,
+                mother_id,
+                dod,
+                yod,
+                team_id,
+                photo,
+                0 AS degree,
+                id::TEXT AS sequence
+        FROM people
+        WHERE deleted_at IS NULL AND id = $personId
+        
+        UNION ALL
+        
+        -- Recursive case: walk up to parents (father OR mother)
+        SELECT
+            p.id,
+            p.firstname,
+            p.surname,
+            p.sex,
+            p.father_id,
+            p.mother_id,
+            p.dod,
+            p.yod,
+            p.team_id,
+            p.photo,
+            a.degree + 1 AS degree,
+            a.sequence || ',' || p.id::TEXT AS sequence
+        FROM people p
+        JOIN ancestors a ON p.id = a.father_id OR p.id = a.mother_id
+        WHERE p.deleted_at IS NULL AND a.degree < $countMax
+        )
+        
+        SELECT *
+        FROM ancestors
         ORDER BY degree, sex DESC;
         ";
     }

--- a/app/Queries/AncestorQuery.php
+++ b/app/Queries/AncestorQuery.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Queries;
+
+use Illuminate\Support\Facades\DB;
+
+class AncestorQuery
+{
+    public static function get(int $personId, int $countMax): string
+    {
+        return match (DB::getDriverName()) {
+            'mysql' => self::getForMySQL($personId, $countMax),
+        };
+    }
+
+    protected static function getForMySQL(int $personId, int $countMax): string
+    {
+        return "
+        WITH RECURSIVE ancestors AS (
+            SELECT
+                id, firstname, surname, sex, father_id, mother_id, dod, yod, team_id, photo,
+                0 AS degree,
+                CAST(id AS CHAR(1024)) AS sequence
+            FROM people
+            WHERE deleted_at IS NULL AND id = $personId
+
+            UNION ALL
+
+            SELECT
+                p.id, p.firstname, p.surname, p.sex, p.father_id, p.mother_id, p.dod, p.yod, p.team_id, p.photo,
+                a.degree + 1 AS degree,
+                CAST(CONCAT_WS(',', a.sequence, p.id) AS CHAR(1024)) AS sequence
+            FROM people p
+            JOIN ancestors a ON a.father_id = p.id
+            WHERE p.deleted_at IS NULL AND a.degree < $countMax
+
+            UNION ALL
+
+            SELECT
+                p.id, p.firstname, p.surname, p.sex, p.father_id, p.mother_id, p.dod, p.yod, p.team_id, p.photo,
+                a.degree + 1 AS degree,
+                CAST(CONCAT_WS(',', a.sequence, p.id) AS CHAR(1024)) AS sequence
+            FROM people p
+            JOIN ancestors a ON a.mother_id = p.id
+            WHERE p.deleted_at IS NULL AND a.degree < $countMax
+        )
+
+        SELECT * FROM ancestors
+        ORDER BY degree, sex DESC;
+        ";
+    }
+}

--- a/app/Queries/DescendantQuery.php
+++ b/app/Queries/DescendantQuery.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Queries;
+
+use Illuminate\Support\Facades\DB;
+
+class DescendantQuery
+{
+    public static function get(int $personId, int $countMax): string
+    {
+        return match (DB::getDriverName()) {
+            'mysql' => self::getForMySQL($personId, $countMax),
+        };
+    }
+
+    protected static function getForMySQL(int $personId, int $countMax): string
+    {
+        return "
+        WITH RECURSIVE descendants AS (
+        SELECT
+            id, firstname, surname, sex, father_id, mother_id, dod, yod, team_id, photo, dob, yob,
+            0 AS degree,
+            CAST(id AS CHAR(1024)) AS sequence
+        FROM people
+        WHERE deleted_at IS NULL AND id = $personId
+
+        UNION ALL
+
+        SELECT
+            p.id, p.firstname, p.surname, p.sex, p.father_id, p.mother_id, p.dod, p.yod, p.team_id, p.photo, p.dob, p.yob,
+            d.degree + 1 AS degree,
+            CONCAT_WS(',', d.sequence, p.id) AS sequence
+        FROM people p
+        JOIN descendants d ON p.father_id = d.id
+        WHERE p.deleted_at IS NULL AND d.degree < $countMax
+
+        UNION ALL
+
+        SELECT
+            p.id, p.firstname, p.surname, p.sex, p.father_id, p.mother_id, p.dod, p.yod, p.team_id, p.photo, p.dob, p.yob,
+            d.degree + 1 AS degree,
+            CONCAT_WS(',', d.sequence, p.id) AS sequence
+        FROM people p
+        JOIN descendants d ON p.mother_id = d.id
+        WHERE p.deleted_at IS NULL AND d.degree < $countMax
+        )
+        SELECT * FROM descendants
+        ORDER BY degree, dob IS NULL, dob, yob IS NULL, yob;
+        ";
+    }
+}


### PR DESCRIPTION
I am trying to make the application as DB agnostic so it can work with postgres as well.

I do understand there are some recursive queries; for now I am offloading then to query builder, where in future I will add postgres compatible queries 