### PR TITLE
Chore: optimize name accessor on person model with test

### DIFF
--- a/app/Models/Person.php
+++ b/app/Models/Person.php
@@ -19,6 +19,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 use Korridor\LaravelHasManyMerged\HasManyMerged;
 use Korridor\LaravelHasManyMerged\HasManyMergedRelation;
 use Override;
@@ -440,11 +441,12 @@ final class Person extends Model implements HasMedia
     /* -------------------------------------------------------------------------------------------- */
     protected function name(): Attribute
     {
-        return Attribute::make(get: function (): ?string {
-            $name = mb_trim("{$this->firstname} {$this->surname}");
-
-            return $name ?: null;
-        });
+        return Attribute::get(
+            fn () => Str::of($this->surname)
+                ->prepend($this->firstname, ' ')
+                ->trim()
+                ->value()
+        );
     }
 
     protected function age(): Attribute

--- a/tests/Feature/Models/PersonTest.php
+++ b/tests/Feature/Models/PersonTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Person;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('returns name', function () {
+    $person = Person::factory()->create([
+        'firstname' => ' John',
+        'surname'   => 'Doe ',
+    ]);
+
+    expect($person->name)->toBe('John Doe');
+});


### PR DESCRIPTION
The `surname` is not nullable in DB, hence the return type will always be string.

I have added `surname` first because, `Str::of()` does not accept null and it needs string only.