### PR TITLE
fix: standardize scope method calls

### DIFF
--- a/app/Livewire/People/Add/Child.php
+++ b/app/Livewire/People/Add/Child.php
@@ -33,8 +33,8 @@ class Child extends Component
     {
         $this->persons = Person::where('id', '!=', $this->person->id)
             ->whereNull($this->person->sex === 'm' ? 'father_id' : 'mother_id')
-            ->YoungerThan($this->person->dob, $this->person->yob)
-            ->OlderThan($this->person->dod, $this->person->yod)
+            ->youngerThan($this->person->dob, $this->person->yob)
+            ->olderThan($this->person->dod, $this->person->yod)
             ->orderBy('firstname')
             ->orderBy('surname')
             ->get()

--- a/app/Livewire/People/Add/Father.php
+++ b/app/Livewire/People/Add/Father.php
@@ -37,7 +37,7 @@ final class Father extends Component
     {
         $this->persons = Person::where('id', '!=', $this->person->id)
             ->where('sex', 'm')
-            ->OlderThan($this->person->dob, $this->person->yob)
+            ->olderThan($this->person->dob, $this->person->yob)
             ->orderBy('firstname')->orderBy('surname')
             ->get()
             ->map(fn ($p): array => [

--- a/app/Livewire/People/Add/Mother.php
+++ b/app/Livewire/People/Add/Mother.php
@@ -37,7 +37,7 @@ final class Mother extends Component
     {
         $this->persons = Person::where('id', '!=', $this->person->id)
             ->where('sex', 'f')
-            ->OlderThan($this->person->dob, $this->person->yob)
+            ->olderThan($this->person->dob, $this->person->yob)
             ->orderBy('firstname')->orderBy('surname')
             ->get()
             ->map(fn ($p): array => [

--- a/app/Livewire/People/Edit/Family.php
+++ b/app/Livewire/People/Edit/Family.php
@@ -40,7 +40,7 @@ final class Family extends Component
         $this->loadData();
 
         $persons = Person::where('id', '!=', $this->person->id)
-            ->OlderThan($this->person->dob, $this->person->yob)
+            ->olderThan($this->person->dob, $this->person->yob)
             ->orderBy('firstname')->orderBy('surname')
             ->get();
 
@@ -55,7 +55,7 @@ final class Family extends Component
         ])->values();
 
         $this->parents = Couple::with(['person_1', 'person_2'])
-            ->OlderThan($this->person->birth_year)
+            ->olderThan($this->person->birth_year)
             ->get()
             ->sortBy('name')
             ->map(fn ($couple): array => [


### PR DESCRIPTION
This pull request standardizes method naming conventions across several Livewire components by updating calls to custom query scopes in the `Person` and `Couple` models. Specifically, it changes method calls from PascalCase (e.g., `OlderThan`) to camelCase (e.g., `olderThan`) to ensure consistency and follow Laravel's typical style for query scopes.

**Standardization of query scope method names:**

* Updated `OlderThan` to `olderThan` and `YoungerThan` to `youngerThan` in queries within the following files and methods:
  - `app/Livewire/People/Add/Child.php` (`mount` method)
  - `app/Livewire/People/Add/Father.php` (`mount` method)
  - `app/Livewire/People/Add/Mother.php` (`mount` method)
  - `app/Livewire/People/Edit/Family.php` (`mount` method, both for people and couples queries) [[1]](diffhunk://#diff-0b1987ab9bcb1282ba76017ab571d2dde19c857e88347cad140722ee578ebaf9L43-R43) [[2]](diffhunk://#diff-0b1987ab9bcb1282ba76017ab571d2dde19c857e88347cad140722ee578ebaf9L58-R58)…ly, Father, and Mother models