### PR TITLE
Bug Fix: children showing below wrong parents, if the $person_sequence match part of $item->sequence

### DIFF
--- a/resources/views/components/tree-node/ancestors.blade.php
+++ b/resources/views/components/tree-node/ancestors.blade.php
@@ -6,7 +6,7 @@
     $person_sequence = $ancestors->firstWhere('id', $person->id)->sequence;
 
     $ancestors_next = $ancestors->where('degree', $level_current)->filter(function ($item) use ($person_sequence): bool {
-        return str_contains($item->sequence, $person_sequence.',');
+        return str_starts_with($item->sequence, $person_sequence.',');
     });
 @endphp
 

--- a/resources/views/components/tree-node/ancestors.blade.php
+++ b/resources/views/components/tree-node/ancestors.blade.php
@@ -6,7 +6,7 @@
     $person_sequence = $ancestors->firstWhere('id', $person->id)->sequence;
 
     $ancestors_next = $ancestors->where('degree', $level_current)->filter(function ($item) use ($person_sequence): bool {
-        return mb_strpos($item->sequence, $person_sequence) !== false;
+        return str_contains($item->sequence, $person_sequence.',');
     });
 @endphp
 

--- a/resources/views/components/tree-node/descendants.blade.php
+++ b/resources/views/components/tree-node/descendants.blade.php
@@ -6,7 +6,7 @@
     $person_sequence = $descendants->firstWhere('id', $person->id)->sequence;
 
     $descendants_next = $descendants->where('degree', $level_current)->filter(function ($item) use ($person_sequence): bool {
-        return str_contains($item->sequence, $person_sequence.',');
+        return str_starts_with($item->sequence, $person_sequence.',');
     });
 @endphp
 

--- a/resources/views/components/tree-node/descendants.blade.php
+++ b/resources/views/components/tree-node/descendants.blade.php
@@ -6,7 +6,7 @@
     $person_sequence = $descendants->firstWhere('id', $person->id)->sequence;
 
     $descendants_next = $descendants->where('degree', $level_current)->filter(function ($item) use ($person_sequence): bool {
-        return mb_strpos($item->sequence, $person_sequence) !== false;
+        return str_contains($item->sequence, $person_sequence.',');
     });
 @endphp
 


### PR DESCRIPTION
In using my own fork of this project, I found that in some cases children could be shown in the wrong location (as well as the right location).

Upon investigating, I found these 2 files to be the source. The sequences are simply the `$person->id` concatenated with a comma ","

As an example, the `$person_sequence` was something like "8,4,1" with the `$item->sequence` being "8,4,11" and "8,4,12"

By suffixing the sequence to test against with the comma separator, we ensure it can only match a real child.


Also since the Sequence strings are made up of only numbers and commas, there is no need to use the more expensive `mb_strpos` and use the simpler `str_contains` function (from PHP 8), which also only return a boolean. An alternative could also be to use the `str_starts_with` function, as this also checks that it is at the start.